### PR TITLE
【必須機能ではありません】add_function_my_page

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -14,7 +14,6 @@ $(function(){
           $('<input type="hidden" name="payjp-token">').val(response.id)
         );
         $('#charge-form').submit();
-          alert("登録が完了しました");
       } else {
         alert("カード情報が正しくありません。");
       }

--- a/app/assets/stylesheets/_user_show.scss
+++ b/app/assets/stylesheets/_user_show.scss
@@ -178,6 +178,26 @@
             font-weight: normal;
           }
         }
+        .list__sold{
+          width: 0;
+          height: 0;
+          border-top: 40px solid #3ccace;
+          border-right: 40px solid transparent;
+          border-bottom: 40px solid transparent;
+          border-left: 40px solid #3ccace;
+          z-index:100;
+          position: absolute;
+          top: 0px;
+          left: 0px;
+          &__inner{
+            color: #fff;
+            transform: rotate(-45deg);
+            font-size: 20px;
+            margin:-16px 0px 0px -32px;
+            letter-spacing: 2px;
+            font-weight: bold;
+          }
+        }
       }
     }
   }

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -18,11 +18,14 @@ class CardController < ApplicationController
       )
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to user_path(current_user.id)
+        redirect_to registration_done_card_index_path
       else
         redirect_to new_card_path
       end
     end
+  end
+
+  def registration_done
   end
 
   def show
@@ -57,8 +60,13 @@ class CardController < ApplicationController
       customer.delete
       @card.delete
     end
-      redirect_to user_path(current_user.id)
+      redirect_to delete_done_card_index_path
   end
+
+  def delete_done
+  end
+
+
 
   private
   def move_to_root

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,11 +21,14 @@ before_action :category_parent_array, only: [:new, :create]
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
+      redirect_to  post_done_items_path
     else
       @item.images.new
       render :new
     end
+  end
+
+  def  post_done
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,19 @@
 class UsersController < ApplicationController
   before_action :move_to_root, except: [:show, :destroy]
+  before_action :set_user_items,except: :edit_done
+
+  def index
+    @sale_items = @items.where(auction_status: "1")
+  end
+
+  def sold_items
+    @sold_items = @items.where(auction_status: "2")
+  end
 
   def show
     @user = User.find(params[:id])
+    @sale_items = @items.where(auction_status: "1")
+    @item_3 = @items.first(3)
   end
 
   def edit_done
@@ -11,5 +22,9 @@ class UsersController < ApplicationController
   private
   def move_to_root
     redirect_to root_path unless user_signed_in?
+  end
+
+  def set_user_items
+    @items = Item.where(user_id: current_user.id).includes(:images).order('created_at DESC')
   end
 end

--- a/app/views/card/delete_done.html.haml
+++ b/app/views/card/delete_done.html.haml
@@ -1,0 +1,9 @@
+= render "top/header"
+.user
+  = render 'users/user_side'
+  .done
+    .done__title
+      クレジット情報を削除しました
+= render "top/lower-photo"
+= render "top/footer"
+= render "top/btn"

--- a/app/views/card/registration_done.html.haml
+++ b/app/views/card/registration_done.html.haml
@@ -1,0 +1,9 @@
+= render "top/header"
+.user
+  = render 'users/user_side'
+  .done
+    .done__title
+      クレジット情報を登録しました
+= render "top/lower-photo"
+= render "top/footer"
+= render "top/btn"

--- a/app/views/items/post_done.html.haml
+++ b/app/views/items/post_done.html.haml
@@ -1,0 +1,11 @@
+= render "top/header"
+.user
+  = render 'users/user_side'
+  .done
+    .done__title
+      商品を出品しましたしました
+    .done__backlink
+      = link_to 'トップページへ戻る', root_path, class: 'link'
+= render "top/lower-photo"
+= render "top/footer"
+= render "top/btn"

--- a/app/views/users/_user_side.html.haml
+++ b/app/views/users/_user_side.html.haml
@@ -1,16 +1,18 @@
 .user__side
   .user__side__menu
+    = link_to "トップページ", root_path, class: "link"
+  .user__side__menu
     = link_to "マイページ", user_path(current_user.id), class: "link"
   .user__side__menu
     = link_to "出品する", new_item_path, data: {"turbolinks" => false} , class: "link"
   .user__side__menu
-    = link_to "出品中の商品一覧", "#", class: "link"
+    = link_to "出品中の商品一覧", users_path, class: "link"
   .user__side__menu
-    = link_to "コメントした商品一覧", "#", class: "link"
+    = link_to "売却済の商品一覧", sold_items_users_path, class: "link"
   .user__side__menu
-    = link_to "コメントされた商品一覧", "#", class: "link"
+    = link_to "コメントした商品一覧　　未実装", "#", class: "link"
   .user__side__menu
-    = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "link"
+    = link_to "コメントされた商品一覧　未実装", "#", class: "link"
   .user__side__subtitle 各種設定
   .user__side__menu
     = link_to "会員情報の編集", edit_user_registration_path, class: "link"
@@ -18,3 +20,5 @@
     = link_to "お届先住所の編集", edit_address_path(current_user.id), class: "link"
   .user__side__menu
     = link_to "お支払い情報の登録/確認/削除", card_path(current_user.id), data: {"turbolinks" => false}, class: "link"
+  .user__side__menu
+    = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "link"

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,0 +1,25 @@
+= render "top/header"
+.item__body
+  .item__body__title
+    出品中の商品一覧
+  .item__body__lists
+    - @sale_items.each do |item|
+      .item__body__lists__list
+        = link_to item_path(item.id) do
+          %figure.list__img
+            = image_tag item.images.first.image.url
+          .list__body
+            %h3.name
+              = item.name
+            .list__price
+              %ul
+                %li
+                  = item.exhibition_price.to_s(:delimited)
+                  円
+                %li
+                  = icon('fa', 'star')
+                  0
+              %p (税込)
+= render "top/lower-photo"
+= render "top/footer"
+= render "top/btn"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -13,7 +13,7 @@
           .prof__data
             登録日：#{current_user.created_at.strftime("%Y年%m月%d日")}
           .prof__data
-            現在の出品数：18
+            現在の出品数：#{@sale_items.count}
           .prof__data
             コメントされた数：5
           .prof__data
@@ -21,45 +21,44 @@
       .user__body__subtitle
         最近出品した商品
       .user__body__lists
-        .user__body__lists__list
-          = link_to "#" do
-            %figure.list__img
-              = image_tag("items/a007.png", alt: "png7")
-            .list__body
-              %h3.name product3
-              .list__price
-                %ul
-                  %li 30,000円
-                  %li>
-                    = icon('fa', 'star')
-                    0
-                %p (税込)
-        .user__body__lists__list
-          = link_to "#" do
-            %figure.list__img
-              = image_tag("items/a004.png", alt: "png4")
-            .list__body
-              %h3.name product2
-              .list__price
-                %ul
-                  %li 20,000円
-                  %li>
-                    = icon('fa', 'star')
-                    0
-                %p (税込)
-        .user__body__lists__list
-          = link_to "#" do
-            %figure.list__img
-              = image_tag("items/a001.png", alt: "png1")
-            .list__body
-              %h3.name product1
-              .list__price
-                %ul
-                  %li 10,000円
-                  %li>
-                    = icon('fa', 'star')
-                    0
-                %p (税込) 
+        - @item_3.each do |item|
+          -if item.auction_status == '売り切れ'
+            .user__body__lists__list
+              = link_to item_path(item.id) do
+                %figure.list__img
+                  = image_tag item.images.first.image.url
+                .list__body
+                  %h3.name
+                    = item.name
+                  .list__price
+                    %ul
+                      %li
+                        = item.exhibition_price.to_s(:delimited)
+                        円
+                      %li
+                        = icon('fa', 'star')
+                        0
+                    %p (税込)
+                .list__sold
+                  .list__sold__inner
+                    sold
+          - else
+            .user__body__lists__list
+              = link_to item_path(item.id) do
+                %figure.list__img
+                  = image_tag item.images.first.image.url
+                .list__body
+                  %h3.name
+                    = item.name
+                  .list__price
+                    %ul
+                      %li
+                        = item.exhibition_price.to_s(:delimited)
+                        円
+                      %li
+                        = icon('fa', 'star')
+                        0
+                    %p (税込)
 - else
   .done#fullsize
     .done__title
@@ -68,6 +67,8 @@
       = link_to '新規会員登録', new_user_registration_path, class: 'link'
     .done__backlink
       = link_to 'ログイン', new_user_session_path, class: 'link'
+    .done__backlink
+      = link_to 'トップページへ戻る', root_path, class: 'link'
 = render "top/lower-photo"
 = render "top/footer"
 = render "top/btn"

--- a/app/views/users/sold_items.html.haml
+++ b/app/views/users/sold_items.html.haml
@@ -1,0 +1,28 @@
+= render "top/header"
+.item__body
+  .item__body__title
+    売却済の商品一覧
+  .item__body__lists
+    - @sold_items.each do |item|
+      .item__body__lists__list
+        = link_to item_path(item.id) do
+          %figure.list__img
+            = image_tag item.images.first.image.url
+          .list__body
+            %h3.name
+              = item.name
+            .list__price
+              %ul
+                %li
+                  = item.exhibition_price.to_s(:delimited)
+                  円
+                %li
+                  = icon('fa', 'star')
+                  0
+              %p (税込)
+          .list__sold
+            .list__sold__inner
+              sold
+= render "top/lower-photo"
+= render "top/footer"
+= render "top/btn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,16 @@ Rails.application.routes.draw do
 
   root 'top#index'
 
-  resources :card
-
-  resources :users, only: :show do
+  resources :card do
     collection do
+      get 'registration_done'
+      get 'delete_done'
+    end
+  end
+
+  resources :users, only: [:index, :show] do
+    collection do
+      get 'sold_items'
       get 'edit_done'
     end
   end
@@ -28,6 +34,7 @@ Rails.application.routes.draw do
     collection do
       get 'get_category_children', defaults: { fomat: 'json'}
       get 'get_category_grandchildren', defaults: { fomat: 'json'}
+      get 'post_done'
     end
   end
 end


### PR DESCRIPTION
# Special Thanks
この度は、コードレビューにご協力いただき、ありがとうございます。いただく指摘につきましては、精一杯対応したいと思います。
今回は、必須機能ではありませんが、担当メンターさんからも「必須機能ではなくてもより良いコードを書くためにプルリクエストをしたほうが良いですよ」とアドバイスを頂いたため投稿させていただきました。
（担当：いりふね）

# What
商品出品機能の実装が完了したので、マイページに商品関連の機能を追加することとした。具体的には以下のことについて取り組んだ。

- マイページ内に最近出品した商品3点が表示される（売却済みを含める）
- マイページ内の現在の出品数を表示
- マイページのサイドバー内の「出品する」にリンクを付ける
- マイページのサイドバー内の「出品中の商品一覧」に遷移先を設定する
- マイページのサイドバー内の「売却済の商品一覧」に遷移先を設定する
- マイページのサイドバー内の「お支払い情報の登録/確認/削除」をクリックし、登録または削除が完了すると完了確認画面を表示する

# Why
マイページ内に商品3点を表示させる理由
フリマサイトは、出品直後のほうが買い手が現れることが多いと聞いたため、最新の商品の販売状況を確認できることはユーザーの利便性向上につながると感じたため。

「出品中の商品一覧」を追加した理由
出品ユーザーにとって取扱商品を一覧できることで、ユーザー自身の商品管理がしやすくなると考えたため。

「売却済の商品一覧」を追加した理由
同じく出品ユーザーにとって売却済商品を一覧できることで、ユーザー自身の商品管理がしやすくなると考えたため。

「お支払い情報の登録/確認/削除」後の完了ページを表示する理由
今回、必須機能にログアウトを行うとログアウトページを表示するように設定したが、同じくクレジットカードの登録完了やクレジットカードの削除の完了ページを実装することで、サイトのテイストを揃えたかったため。またユーザーにとっても入力情報が登録された旨が確認できるのは利用しやすさに繋がると考えたため。
なお、会員情報の編集や住所の編集後も同様に完了画面へ遷移する機能はすでに実装済みである。こちらは、Trello必須項目の「マイページのマークアップ」のタスクで実装した。

# Views
マイページの画面
右のメイン画面内の「現在の出品数」はユーザーの出品中の商品が表示されている
右下は、最近出品した商品3点が表示されている
<img width="1439" alt="スクリーンショット 2020-06-01 18 16 10" src="https://user-images.githubusercontent.com/64057202/83394705-fc376e80-a433-11ea-8d45-58b5163a6972.png">

サイドバーの「出品する」にリンクを実装
商品出品ページのマークアップは、現在、チームメンバーが作成中です。
![2b2e644a3fdd0c12339597cb42b9164f](https://user-images.githubusercontent.com/64057202/83395059-9a2b3900-a434-11ea-8fd6-c54ea7e2f17a.gif)


出品中商品一覧と売却済商品一覧に遷移先がある
![72727a973bb4d7c684d8953e22ca8830](https://user-images.githubusercontent.com/64057202/83394912-63552300-a434-11ea-8249-be43704d38ce.gif)

クレジット情報を削除すると完了画面が表示される
![c52f1ba1aa8ef18c8219e621384d0c21](https://user-images.githubusercontent.com/64057202/83395153-c34bc980-a434-11ea-881e-1597ec98896e.gif)

クレジット登録が完了すると完了画面が表示される
![e422cdeaeb88103bc1838a156f033190](https://user-images.githubusercontent.com/64057202/83395270-f1c9a480-a434-11ea-8211-c2367fb13310.gif)

# Other
コメント関連の機能は未実装です。コメント機能を実装した後、再追加を行います。