### PR TITLE
商品詳細ページのマークアップ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import 'mixin/underline';
 @import 'mixin/opacity';
 @import 'mixin/flex_align-c';
+@import 'mixin/blue_link';
 @import 'modules/header';
 @import 'modules/main';
 @import 'modules/lower-photo';
@@ -13,5 +14,7 @@
 @import 'done';
 @import 'user_show';
 @import 'card';
+@import 'modules/item_main_show';
+@import 'modules/nav';
 @import 'font-awesome-sprockets';
 @import 'font-awesome';

--- a/app/assets/stylesheets/mixin/_blue_link.scss
+++ b/app/assets/stylesheets/mixin/_blue_link.scss
@@ -1,0 +1,9 @@
+@mixin blue_link(){
+  line-height: 48px;
+  background: #3ccace;
+  border: 1px solid #3ccace;
+  color: #fff;
+  width: 60%;
+  font-size: 18px;
+  border-radius: 100px;
+}

--- a/app/assets/stylesheets/modules/item_main_show.scss
+++ b/app/assets/stylesheets/modules/item_main_show.scss
@@ -1,0 +1,212 @@
+.mainShow{
+  background-color: #f8f8f8;
+  &__box{
+    padding:40px;
+    margin: 0 auto;
+    &__content{
+      width: 700px;
+      margin: 0 auto;
+      &__top{
+        &__itemBox{
+          background-color: #fff;
+          padding: 24px 40px 40px;
+          margin-bottom: 10px;
+          h2{
+            text-align: center;
+            font-weight: bold;
+            font-size: 24px;
+          }
+          &__images{
+            margin-top: 16px;
+            .image__main{
+              display: flex;
+              position: relative;
+              &__list{
+                @include flex_align-c();
+                flex-direction: column;
+                width: 560px;
+                margin: 0 auto;
+                .main__photo{
+                  object-fit: cover;
+                  height: 346px;
+                  width: 100%;
+                  vertical-align: bottom;
+                }
+                .image__box{
+                  width: 560px;
+                  .image__sub{
+                    display: flex;
+                    justify-content: left;
+                    flex-wrap: wrap;
+                    margin-top: 10px;
+                    margin-left: 80px;
+                    .image__sub__list{
+                      @include flex_align-c();
+                      flex-direction: column;
+                      width: 15%;
+                      margin-right: 10px;
+                      .sub__photo{
+                        object-fit: cover;
+                        height: 87px;
+                        width: 100%;
+                        vertical-align: bottom;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          &__price{
+            margin: 24px 0 24px;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            .price{
+              font-size: 40px;
+              font-weight: bold;
+              margin-right: 10px;
+            }
+            &__detail{
+              font-size: 16px;
+            }
+          }
+          &__explanation{
+            line-height: 1.5;
+            font-size: 18px;
+            margin-bottom: 30px;
+          }
+          &__table{
+            margin-bottom: 20px;
+            table{
+              width: 100%;
+              height: 375px;
+              border-collapse: collapse;
+              border: 1px solid #f8f8f8;
+              tbody{
+                tr{
+                  th{
+                    width: 20%;
+                    background-color: #eee;
+                    font-weight: 400;
+                    padding: 8px;
+                    border: 1px solid #dedede;
+                    font-size: 14px;
+                    text-align: center;
+                  }
+                  td{
+                    width: 61%;
+                    padding: 15px 15px;
+                    border: 1px solid #dedede;
+                    font-size: 14px;
+                    a{
+                      text-decoration: none;
+                      color: #3ccace;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          &__option{
+            display: flex;
+            justify-content: space-between;
+            .like{
+              margin-top: 10px;
+              &__list{
+                margin-right: auto;
+                padding: 6px 10px;
+                border-radius: 40px;
+                color: #3ccace;
+                border: 1px solid #ffb340;
+              }
+            }
+            .report{
+              margin-top: 10px;
+              display: flex;
+              &__list{
+                font-size: 14px;
+                a{
+                  padding: 6px 10px;
+                  display: inline-block;
+                  border-radius: 4px;
+                  color: #333;
+                  border: 1px solid #333;
+                  text-decoration: none;
+                }
+              }
+            }
+          }
+        }
+        &__editDeleteBuy{
+          display: flex;
+          flex-direction: column;
+          a{
+            @include blue_link();
+            text-decoration: none;
+            text-align: center;
+            margin: 20px auto;
+            @include opacity();
+          }
+        }
+        &__commentBox{
+          padding: 24px;
+          background-color: #fff;
+          margin: 10px 0;
+          text-align: center;
+          .new_comment{
+            .text_area{
+              width: 100%;
+              min-height: 104px;
+              padding: 10px;
+            }
+            .note{
+              padding: 8px;
+              font-size: 14px;
+              background-color: #f8f8f8;
+              margin: 10px 0;
+              text-align: left;
+            }
+            .comment_btn{
+              @include blue_link();
+              @include opacity();
+            }
+          }
+        }
+      }
+      .links{
+        list-style: none;
+        &__before{
+          float: left;
+          .angle__left{
+            text-decoration: none;
+            color: #3ccace;
+          }
+        }
+        &__after{
+          float: right; 
+          .angle__right{
+            text-decoration: none;
+            color: #3ccace;
+          }
+        }
+        &::after{
+          display: block;
+          content: "";
+          clear: both;
+        }
+      }
+      &__related{
+        .related{
+          display: block;
+          margin: 24px 0 8px;
+          color: #3ccace;
+          text-decoration: none;
+          font-weight: bold;
+          font-size: 22px;
+          position: relative;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/main.scss
+++ b/app/assets/stylesheets/modules/main.scss
@@ -293,6 +293,7 @@
               }
             }
             .list__body{
+              width: 220px;
               background-color: white;
               color:#333;
               padding: 16px;
@@ -301,6 +302,8 @@
                 line-height: 1.5;
                 font-size: 16px;
                 text-align: left;
+                text-overflow: ellipsis;
+                white-space: nowrap;
               }
             }
             .list__price{

--- a/app/assets/stylesheets/modules/nav.scss
+++ b/app/assets/stylesheets/modules/nav.scss
@@ -1,0 +1,28 @@
+.breadcrumb{
+  width: 100%;
+  border-top:1px solid #eee;
+  box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+  position: relative;
+  padding: 0 60px;
+  ul{
+    padding: 17px 0 16px;
+    width: 100%;
+    max-width: 1040px;
+    font-size: 14px;
+    margin: 0 auto;
+    li{
+      padding-right: 10px;
+      float: left;
+      a{
+        text-decoration: none;
+        color: #333;
+      }
+    }
+    &::after{
+      display: block;
+      content:"";
+      clear:both;
+    }
+    
+  }
+}

--- a/app/views/items/_main_show.html.haml
+++ b/app/views/items/_main_show.html.haml
@@ -1,0 +1,102 @@
+.mainShow
+  .mainShow__box
+    .mainShow__box__content
+      .mainShow__box__content__top
+        .mainShow__box__content__top__itemBox
+          %h2= @item.name
+          .mainShow__box__content__top__itemBox__images
+            %ul.image__main
+              %li.image__main__list
+                = image_tag(@images_first.image.url, class: "main__photo")
+                .image__box
+                  %ul.image__sub
+                    - @images.each do |img|
+                      %li.image__sub__list
+                        = image_tag(img.image.url, class: "sub__photo", size: "75x75")
+          .mainShow__box__content__top__itemBox__price
+            %span.price
+              = @item.exhibition_price.to_s(:delimited)
+              円
+            .mainShow__box__content__top__itemBox__price__detail
+              %span
+                (税込)
+              %span
+                送料込み 
+          .mainShow__box__content__top__itemBox__explanation
+            = @item.item_explanation
+          .mainShow__box__content__top__itemBox__table
+            %table 
+              %tr 
+                %th 出品者
+                %td= @user.nickname
+              %tr 
+                %th カテゴリー
+                - if @category_id == 46 or @category_id == 74 or @category_id == 134 or @category_id == 142 or @category_id == 147 or @category_id == 150 or @category_id == 158
+                  %td
+                    = link_to "#{@category_child.name}","#"
+                    %br= link_to "#{@category_grandchild.name}","#" 
+                -else
+                  %td
+                    = link_to "#{@category_parent.name}","#"
+                    %br= link_to "#{@category_child.name}","#"
+                    = link_to "#{@category_grandchild.name}","#"
+              %tr
+                %th ブランド
+                %td= @item.brand_name
+              %tr
+                %th 商品のサイズ
+                %td
+              %tr
+                %th 商品の状態
+                %td= @item.item_status
+              %tr
+                %th 配送料の負担
+                %td= @item.delivery_fee
+              %tr
+                %th 発送元の地域
+                %td= link_to "#{@item.shipping_origin}","#"
+              %tr
+                %th 発送日の目安
+                %td= @item.days_until_shipping
+          .mainShow__box__content__top__itemBox__option
+            %ul.like
+              %li.like__list
+                = icon('fa', 'star')
+                お気に入り 0
+            %ul.report
+              %li.report__list
+                = link_to "#" do
+                  = icon('fa', 'flag')
+                  不適切な商品の通報
+        .mainShow__box__content__top__editDeleteBuy
+          - if current_user == @user
+            = link_to "商品の編集", "#", class: "edit"
+            = link_to "商品の削除", "#", class: "destory"
+          - elsif user_signed_in?
+            = link_to "購入画面に進む", "#", class: "pay"
+          - else
+        .mainShow__box__content__top__commentBox
+          .mainShow__box__content__top__commentBox__contents
+          = form_with url: root_path, class: "new_comment" do |f|
+            = f.text_area "", required: "required", class: "text_area"
+            %p.note
+              相手のことを考え丁寧なコメントを心がけましょう。
+              %br 不快な言葉遣いなどは利用制限や退会処分となることがあります。
+            %button.comment_btn{type:"submit"}
+              = icon('fa', 'comment')
+              コメントする
+        %ul.links
+          %li.links__before
+            = link_to "#", class: "angle__left" do
+              = icon('fa', 'angle-left')
+              %span 前の商品
+          %li.links__after
+            = link_to "#", class: "angle__right" do
+              %span 後ろの商品
+              = icon('fa', 'angle-right')
+      .mainShow__box__content__related
+        - if @category_id == 46 or @category_id == 74 or @category_id == 134 or @category_id == 142 or @category_id == 147 or @category_id == 150 or @category_id == 158
+          = link_to "#{@category_child.name}をもっと見る", "#", class: "related"
+        - else
+          = link_to "#{@category_parent.name}をもっと見る", "#", class: "related"
+

--- a/app/views/items/_nav.html.haml
+++ b/app/views/items/_nav.html.haml
@@ -1,0 +1,20 @@
+.breadcrumb
+  %ul 
+    %li
+      = link_to "FURIMA", root_path
+    %li
+      = icon('fa', 'angle-right')
+    %li
+      = link_to "ベビー・キッズ", "#" 
+    %li
+      = icon('fa', 'angle-right')
+    %li
+      = link_to "ベビー服(男女兼用)~95cm", "#" 
+    %li
+      = icon('fa', 'angle-right')
+    %li
+      = link_to "アウター", "#" 
+    %li
+      = icon('fa', 'angle-right')
+    %li
+      = link_to "product3", "#" 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -6,7 +6,7 @@
     - @items.each do |item|
       -if item.auction_status == 2
         .item__body__lists__list
-          = link_to "#" do
+          = link_to item_path(item.id) do
             %figure.list__img
               = image_tag item.images.first.image.url
             .list__body
@@ -26,7 +26,7 @@
                 sold
       - else
         .item__body__lists__list
-          = link_to "#" do
+          = link_to item_path(item.id) do
             %figure.list__img
               = image_tag item.images.first.image.url
             .list__body

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,57 +1,6 @@
 = render 'top/header'
-%h1 showページ
-%h3 商品名： #{@item.name}
-%h3 写真
-.images_first
-  = image_tag(@images_first.image.url, size:"320x240")
-.images
-  - @images.each do |img|
-    = image_tag(img.image.url)
-%h3 価格
-.price
-  = @item.exhibition_price.to_s(:delimited)
-  円
-%h3 説明
-.explanetion
-  = @item.item_explanation
-%h3 出品者
-.nickname
-  = @user.nickname
-- if @category_id == 46 or @category_id == 74 or @category_id == 134 or @category_id == 142 or @category_id == 147 or @category_id == 150 or @category_id == 158
-  %h3 カテゴリー
-  .category__parent
-    = @category_child.name
-  .category__child
-    = @category_grandchild.name
-- else
-  %h3 カテゴリー
-  .category__parent
-    = @category_parent.name
-  .category__child
-    = @category_child.name
-  .category__grandchild
-    = @category_grandchild.name
-%h3 ブランド
-.brand
-  = @item.brand_name
-%h3 商品の状態
-.status
-  = @item.item_status
-%h3 発送料の負担
-.fee
-  = @item.delivery_fee
-%h3 発送元の地域
-.origin
-  = @item.shipping_origin
-%h3 発送の目安
-.day
-  = @item.days_until_shipping
-- if current_user == @user
-  = link_to "商品の編集", "#",class: "edit"
-  = link_to "商品の削除", "#",class: "destory"
-- elsif user_signed_in?
-  = link_to "購入画面に進む", "#",class: "pay"
-- else
-
+= render 'items/nav'
+= render 'items/main_show'
 = render 'top/lower-photo'
 = render 'top/footer'
+= render "top/btn"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@ ActiveRecord::Schema.define(version: 2020_05_28_094129) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "post_code", null: false
-    t.integer "preficture", null: false
+    t.string "preficture", null: false
     t.string "city", null: false
     t.string "address", null: false
     t.string "building_name"


### PR DESCRIPTION
# What
### BEMに沿った書き方でCSSを記述し、見本サイトFURIMAとほぼ同じ見た目ができている。
#### hamlファイル
- app/view/items/show.html.hamlの作成
　- このファイル内にrenderを記述し、部分テンプレートファイルを呼び出すよう記述しております。
- app/view/items/_main_show.html.hamlの作成
  - サブ画像は商品出品時に最大10枚登録することができるので10枚表示で収まるよう調整しております。
  - 商品編集、削除、購入のボタンをそれぞれログイン時、ログアウト時、出品者の場合でlinkの表示が変わるようにしております。
- app/view/items/_nav.html.hamlの作成
  - パンくず用の部分テンプレートファイルになります。表示内容については、パンくず実装時に調整します。

#### scssファイル
- app/assets/stylesheets/modules/item_main_show.scssの作成
  - _main_show.html.haml部分のscssを記述しております。
- app/assets/stylesheets/modules/nav.scssの作成
  - _nav.html.haml部分のscssを記述しております。
- app/assets/stylesheets/mixin/_blue_link.scssの作成
  - リファクタリングを行うにあたり、item_main_show.scss内のlinkについて装飾の内容が重複している箇所があるため、mixinフォルダ内に呼び出し用のファイルを記述しております。
- app/assets/stylesheets/application.scssの編集
  - 上記で作成したファイルの@importの記述を追加しております。

#### 実装時の動作確認時に気づき、追加修正を行ないました。
- app/assets/stylesheets/modules/main.scssの編集
  - トップページ内のピックアップカテゴリーに表示される商品の名前が長くなった場合にビューが崩れるため、長くなった場合は、点表示するようにしております。
- app/view/items/show.html.hamlの編集
  - 新規投稿商品一覧の商品をクリックすると商品詳細ページに遷移するようリンクを修正しております。


# Why
- 商品詳細情報の装飾をすることにより、ユーザーが使用する際の利便性を向上させるため


<img width="1440" alt="画像１" src="https://user-images.githubusercontent.com/64079276/83497490-85fb4080-a4f5-11ea-83e9-5a4abd68e60e.png">

<img width="1440" alt="画像２" src="https://user-images.githubusercontent.com/64079276/83497516-8e537b80-a4f5-11ea-9144-234b1e52467a.png">

<img width="1440" alt="画像３" src="https://user-images.githubusercontent.com/64079276/83497592-a4f9d280-a4f5-11ea-93b0-a5989ff98cfa.png">


<img width="1439" alt="画像３-２" src="https://user-images.githubusercontent.com/64079276/83497539-96abb680-a4f5-11ea-8eb9-1aa57fb22550.png">

<img width="1439" alt="画像３-３" src="https://user-images.githubusercontent.com/64079276/83497571-9ca19780-a4f5-11ea-9bfd-7ac28d103831.png">

![画像４](https://user-images.githubusercontent.com/64079276/83497600-a9be8680-a4f5-11ea-8c8d-b9a4d7814245.jpg)
