### PR TITLE
 商品削除機能の導入

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,5 +16,6 @@
 @import 'card';
 @import 'modules/item_main_show';
 @import 'modules/nav';
+@import 'modules/flash';
 @import 'font-awesome-sprockets';
 @import 'font-awesome';

--- a/app/assets/stylesheets/modules/flash.scss
+++ b/app/assets/stylesheets/modules/flash.scss
@@ -1,0 +1,11 @@
+  .notice {
+    background-color: #38AEF0;
+    color: #fff;
+    text-align: center;
+  }
+
+  .alert {
+    background-color: #F35500;
+    color: #fff;
+    text-align: center;
+  }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
 before_action :category_parent_array, only: [:new, :create]
 before_action :set_item, only: [:show, :destroy]
+before_action :show_all_instance, only: [:show, :destroy]
 
   def index
     @items = Item.includes(:images).order('created_at DESC')
@@ -37,21 +38,18 @@ before_action :set_item, only: [:show, :destroy]
   end
 
   def show
-    @user = User.find(@item.user_id)
-    @images = Image.where(item_id: params[:id])
-    @images_first = Image.where(item_id: params[:id]).first
-    @category_id = @item.category_id
-    @category_parent = Category.find(@category_id).parent.parent
-    @category_child = Category.find(@category_id).parent
-    @category_grandchild = Category.find(@category_id)
   end
 
   def update
   end
   
   def destroy
-    @item.destroy
-    redirect_to  delete_done_items_path
+    if @item.destroy
+      redirect_to  delete_done_items_path
+    else
+      flash.now[:alert] = '削除できませんでした'
+      render :show
+    end
   end
 
   private
@@ -66,5 +64,15 @@ before_action :set_item, only: [:show, :destroy]
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def show_all_instance
+    @user = User.find(@item.user_id)
+    @images = Image.where(item_id: params[:id])
+    @images_first = Image.where(item_id: params[:id]).first
+    @category_id = @item.category_id
+    @category_parent = Category.find(@category_id).parent.parent
+    @category_child = Category.find(@category_id).parent
+    @category_grandchild = Category.find(@category_id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
 before_action :category_parent_array, only: [:new, :create]
+before_action :set_item, only: [:show, :destroy]
 
   def index
     @items = Item.includes(:images).order('created_at DESC')
@@ -29,13 +30,13 @@ before_action :category_parent_array, only: [:new, :create]
   end
 
   def  post_done
+    @item = Item.where(user_id: current_user.id).last
   end
 
   def edit
   end
 
   def show
-    @item = Item.find(params[:id])
     @user = User.find(@item.user_id)
     @images = Image.where(item_id: params[:id])
     @images_first = Image.where(item_id: params[:id]).first
@@ -47,8 +48,10 @@ before_action :category_parent_array, only: [:new, :create]
 
   def update
   end
-
+  
   def destroy
+    @item.destroy
+    redirect_to  delete_done_items_path
   end
 
   private
@@ -59,5 +62,9 @@ before_action :category_parent_array, only: [:new, :create]
   def category_parent_array
     @category_parent_array = Category.where(ancestry: nil).each do |parent|
     end
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
-  has_many :images
+  has_many :images, dependent: :destroy
   belongs_to :category
 
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/views/items/_main_show.html.haml
+++ b/app/views/items/_main_show.html.haml
@@ -71,7 +71,7 @@
         .mainShow__box__content__top__editDeleteBuy
           - if current_user == @user
             = link_to "商品の編集", "#", class: "edit"
-            = link_to "商品の削除", "#", class: "destory"
+            = link_to "商品の削除", item_path(@item.id), method: :delete, class: "destory"
           - elsif user_signed_in?
             = link_to "購入画面に進む", "#", class: "pay"
           - else

--- a/app/views/items/delete_done.html.haml
+++ b/app/views/items/delete_done.html.haml
@@ -1,0 +1,9 @@
+= render "top/header"
+.done#fullsize
+  .done__title
+    商品を削除しました
+  .done__backlink
+    = link_to 'トップページへ戻る', root_path, class: 'link'
+= render "top/lower-photo"
+= render "top/footer"
+= render "top/btn"

--- a/app/views/items/post_done.html.haml
+++ b/app/views/items/post_done.html.haml
@@ -1,11 +1,13 @@
 = render "top/header"
-.user
-  = render 'users/user_side'
-  .done
-    .done__title
-      商品を出品しましたしました
-    .done__backlink
-      = link_to 'トップページへ戻る', root_path, class: 'link'
+.done#fullsize
+  .done__title
+    商品を出品しました
+  .done__backlink
+    = link_to 'トップページへ戻る', root_path, class: 'link'
+  .done__backlink
+    = link_to '出品した商品を確認する', item_path(@item), class: 'link'
+  .done__backlink
+    = link_to '出品中の商品一覧を見る', users_path, class: 'link'
 = render "top/lower-photo"
 = render "top/footer"
 = render "top/btn"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,4 +9,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    .notifications
+    - flash.each do |key, value|
+      = content_tag(:div, value, class: key)
     = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       get 'get_category_children', defaults: { fomat: 'json'}
       get 'get_category_grandchildren', defaults: { fomat: 'json'}
       get 'post_done'
+      get 'delete_done'
     end
   end
 end


### PR DESCRIPTION
# What
### ①商品削除ができる
- app/controllers/items_controller.rbの編集
  - destroyアクションを定義
  - show、destoryアクション内で記述に重複があるため、set_itemメソッドを作成し、before_actionを記述
- app/models/item.rbの編集
  - 商品削除時に共に写真が削除されるようdependent: :destroyを記述
- app/views/items/_main_show.html.hamlの編集
  - 商品削除のリンクにパスを記述
- config/routes.rbの編集
  - 商品を削除後にリダイレクトする専用のルートを作成
- views/items/delete_done.html.hamlの作成
  - トップページへのリンクと削除した旨を伝える文章を記述


### ②投稿者だけが削除できるようになっている
- 出品者にのみ商品削除のリンクが表示されるよう商品詳細ページのマークアップ時にif文による条件分岐を記述しておりました。（_main_show.html.haml）

### 実装時の動作確認時に気づき追加で修正作業を行なっています。
- app/views/items/post_done.html.hamlの編集
  - このファイルは、商品出品後に遷移するビューで出品した商品の詳細情報のリンクとログインユーザーの出品一覧のリンクを追加しておりまう。



# Why
- 出品を取り止めたい場合に投稿を削除できるようにするため

# View
## delete_done.html.haml

<img width="1440" alt="削除後遷移画面" src="https://user-images.githubusercontent.com/64079276/83620449-4f422a80-a5c8-11ea-812f-40ca357cd1c7.png">

## post_done.html.haml

<img width="1440" alt="出品後遷移画面" src="https://user-images.githubusercontent.com/64079276/83620473-59642900-a5c8-11ea-8ca3-2d945f4cc82e.png">
